### PR TITLE
Add link to `_all` in the "What can I explore" box

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,7 @@ import { H1 } from "@/components/datacite/Headings";
 import InfoCard from "@/components/InfoCard";
 import DisplayEntities from "./DisplayEntities";
 import SearchEntities from "./SearchEntities";
+import { ALL_OF_DATACITE_ID } from "@/constants";
 
 export default async function Page({ searchParams }: PageProps<"/">) {
   const { query = undefined } = await searchParams;
@@ -36,7 +37,19 @@ function InfoCards() {
       <InfoCard
         icon={Search}
         title="What can I explore?"
-        body="Search for a DataCite Member, Consortium Organization, or Repository to view a metadata quality snapshot and explore opportunities for improvement."
+        body={
+          <>
+            Search for a DataCite Member, Consortium Organization, or Repository
+            to view a metadata quality snapshot and explore opportunities for
+            improvement. You can also view a{" "}
+            <Link
+              href={ALL_OF_DATACITE_ID}
+              className="text-datacite-blue-light"
+            >
+              snapshot for all DataCite metadata.
+            </Link>
+          </>
+        }
       />
       <InfoCard
         icon={BookOpen}


### PR DESCRIPTION
## Purpose
Adds a link to `_all` in the "What can I explore" box on the homepage.

[Preview deployment](https://puli-mba8lm7hr-datacite.vercel.app/)

closes: https://github.com/datacite/product-backlog/issues/833

## Approach

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->

## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
